### PR TITLE
fix ci node version warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,9 +40,12 @@ jobs:
 
       - name: Test with tox
         run: tox
-
+      - name:                   Workaround for codecov/feedback#263
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: captainhammy/houdini-core-tools
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: tox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
+        uses: codecov/codecov-action@v4
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: captainhammy/houdini-core-tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,12 +40,12 @@ jobs:
 
       - name: Test with tox
         run: tox
-      - name:                   Workaround for codecov/feedback#263
+
+      - name: Workaround for codecov/feedback#263
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: captainhammy/houdini-core-tools
-          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: pypy${{ matrix.python-version }}
 


### PR DESCRIPTION
This PR fixes warnings about Node versions by updating the workflows identified in the warnings.

Resolves #1