### PR TITLE
ci: install coverage when testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           client_secret_key: ${{ secrets.SESI_SECRET_KEY }}
 
       - name: Install dependencies
-        run: python3 -m pip install tox tox-gh-actions
+        run: python3 -m pip install tox tox-gh-actions coverage
 
       - name: Test with tox
         run: tox


### PR DESCRIPTION
This PR adds the coverage package to the list of installed dependencies so that the codecov action can properly upload the results